### PR TITLE
First working version of osqp-matlab-cmake-buildsystem

### DIFF
--- a/3rdparty/ycm-0.12/AddInstallRPATHSupport.cmake
+++ b/3rdparty/ycm-0.12/AddInstallRPATHSupport.cmake
@@ -1,0 +1,237 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+AddInstallRPATHSupport
+----------------------
+
+Add support to RPATH during installation to the project and the targets
+
+.. command:: add_install_rpath_support
+
+  Add support to RPATH during installation to the project::
+
+  .. code-block:: cmake
+
+    add_install_rpath_support([BIN_DIRS dir [dir]]
+                              [LIB_DIRS dir [dir]]
+                              [INSTALL_NAME_DIR [dir]]
+                              [DEPENDS condition [condition]]
+                              [USE_LINK_PATH])
+
+  Normally (depending on the platform) when you install a shared
+  library you can either specify its absolute path as the install name,
+  or leave just the library name itself. In the former case the library
+  will be correctly linked during run time by all executables and other
+  shared libraries, but it must not change its install location. This
+  is often the case for libraries installed in the system default
+  library directory (e.g. ``/usr/lib``).
+  In the latter case, instead, the library can be moved anywhere in the
+  file system but at run time the dynamic linker must be able to find
+  it. This is often accomplished by setting environmental variables
+  (i.e. ``LD_LIBRARY_PATH`` on Linux).
+  This procedure is usually not desirable for two main reasons:
+
+  - by setting the variable you are changing the default behaviour
+    of the dynamic linker thus potentially breaking executables (not as
+    destructive as ``LD_PRELOAD``)
+  - the variable will be used only by applications spawned by the shell
+    and not by other processes.
+
+  RPATH aims in solving the issues introduced by the second
+  installation method. Using run-path dependent libraries you can
+  create a directory structure containing executables and dependent
+  libraries that users can relocate without breaking it.
+  A run-path dependent library is a dependent library whose complete
+  install name is not known when the library is created.
+  Instead, the library specifies that the dynamic loader must resolve
+  the library’s install name when it loads the executable that depends
+  on the library. The executable or the other shared library will
+  hardcode in the binary itself the additional search directories
+  to be passed to the dynamic linker. This works great in conjunction
+  with relative paths.
+  This command will enable support to RPATH to your project.
+  It will enable the following things:
+
+   - If the project builds shared libraries it will generate a run-path
+     enabled shared library, i.e. its install name will be resolved
+     only at run time.
+   - In all cases (building executables and/or shared libraries)
+     dependent shared libraries with RPATH support will have their name
+     resolved only at run time, by embedding the search path directly
+     into the built binary.
+
+  The command has the following parameters:
+
+  Options:
+   - ``USE_LINK_PATH``: if passed the command will automatically adds to
+     the RPATH the path to all the dependent libraries.
+
+  Arguments:
+   - ``BIN_DIRS`` list of directories when the targets (executable and
+     plugins) will be installed.
+   - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+     directories will be added "relative" w.r.t. the ``BIN_DIRS`` and
+     ``LIB_DIRS``.
+   - ``INSTALL_NAME_DIR`` directory where the libraries will be installed.
+     This variable will be used only if ``CMAKE_SKIP_RPATH`` or
+     ``CMAKE_SKIP_INSTALL_RPATH`` is set to ``TRUE`` as it will set the
+     ``INSTALL_NAME_DIR`` on all targets
+   - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+     RPATH, for example ``FOO; NOT BAR``.
+
+  Note: see https://gitlab.kitware.com/cmake/cmake/issues/16589 for further
+  details.
+
+.. command:: target_append_install_rpath
+
+  Add extra paths to RPATH for a specific target::
+
+  .. code-block:: cmake
+
+    target_append_install_rpath(<target>
+                                <INSTALL_DESTINATION destination>
+                                [LIB_DIRS dir [dir]]
+                                [DEPENDS condition [condition]])
+
+  Arguments:
+   - ``INSTALL_DESTINATION`` path where the target will be installed.
+   - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+     directories will be added "relative" w.r.t. the ``INSTALL_DESTINATION``.
+   - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+     RPATH, for example ``FOO; NOT BAR``.
+
+#]=======================================================================]
+
+include(CMakeParseArguments)
+
+
+macro(__AddInstallRPATHSupport_GET_SYSTEM_LIB_DIRS _var)
+  # Find system implicit lib directories
+  set(${_var} ${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES})
+  if(EXISTS "/etc/debian_version") # is this a debian system ?
+    if(CMAKE_LIBRARY_ARCHITECTURE)
+      list(APPEND ${_var} "/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+                          "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+    endif()
+  endif()
+endmacro()
+
+
+macro(__AddInstallRPATHSupport_APPEND_RELATIVE_RPATH _var _bin_dir _lib_dir)
+  file(RELATIVE_PATH _rel_path ${_bin_dir} ${_lib_dir})
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    list(APPEND ${_var} "@loader_path/${_rel_path}")
+  else()
+    list(APPEND ${_var} "\$ORIGIN/${_rel_path}")
+  endif()
+endmacro()
+
+
+
+function(ADD_INSTALL_RPATH_SUPPORT)
+
+  set(_options USE_LINK_PATH)
+  set(_oneValueArgs INSTALL_NAME_DIR)
+  set(_multiValueArgs BIN_DIRS
+                      LIB_DIRS
+                      DEPENDS)
+
+  cmake_parse_arguments(_ARS "${_options}"
+                             "${_oneValueArgs}"
+                             "${_multiValueArgs}"
+                             "${ARGN}")
+
+  # if either RPATH or INSTALL_RPATH is disabled
+  # and the INSTALL_NAME_DIR variable is set, then hardcode the install name
+  if(CMAKE_SKIP_RPATH OR CMAKE_SKIP_INSTALL_RPATH)
+    if(DEFINED _ARS_INSTALL_NAME_DIR)
+      set(CMAKE_INSTALL_NAME_DIR ${_ARS_INSTALL_NAME_DIR} PARENT_SCOPE)
+    endif()
+  endif()
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    # Enable RPATH on OSX.
+    set(CMAKE_MACOSX_RPATH TRUE PARENT_SCOPE)
+
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
+    # This is relative RPATH for libraries built in the same project
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        foreach(bin_dir ${_ARS_LIB_DIRS} ${_ARS_BIN_DIRS})
+          __AddInstallRPATHSupport_append_relative_rpath(CMAKE_INSTALL_RPATH ${bin_dir} ${lib_dir})
+        endforeach()
+      endif()
+    endforeach()
+    if(NOT "${CMAKE_INSTALL_RPATH}" STREQUAL "")
+      list(REMOVE_DUPLICATES CMAKE_INSTALL_RPATH)
+    endif()
+    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} PARENT_SCOPE)
+
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ${_ARS_USE_LINK_PATH} PARENT_SCOPE)
+
+  endif()
+
+endfunction()
+
+
+function(TARGET_APPEND_INSTALL_RPATH _target)
+  set(_options )
+  set(_oneValueArgs INSTALL_DESTINATION)
+  set(_multiValueArgs LIB_DIRS
+                      DEPENDS)
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+  cmake_parse_arguments(_ARS "${_options}"
+                             "${_oneValueArgs}"
+                             "${_multiValueArgs}"
+                             "${ARGN}")
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
+    get_target_property(_current_rpath ${_target} INSTALL_RPATH)
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        __AddInstallRPATHSupport_append_relative_rpath(_current_rpath ${_ARS_INSTALL_DESTINATION} ${lib_dir})
+      endif()
+    endforeach()
+    set_target_properties(${_target} PROPERTIES INSTALL_RPATH "${_current_rpath}")
+  endif()
+
+endfunction()

--- a/3rdparty/ycm-0.12/AddUninstallTarget.cmake
+++ b/3rdparty/ycm-0.12/AddUninstallTarget.cmake
@@ -1,0 +1,102 @@
+#.rst:
+# AddUninstallTarget
+# ------------------
+#
+# Add the "uninstall" target for your project::
+#
+#   include(AddUninstallTarget)
+#
+#
+# will create a file ``cmake_uninstall.cmake`` in the build directory and add a
+# custom target ``uninstall`` (or ``UNINSTALL`` on Visual Studio and Xcode) that
+# will remove the files installed by your package (using
+# ``install_manifest.txt``).
+# See also
+# https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+#
+# The :module:`AddUninstallTarget` module must be included in your main
+# ``CMakeLists.txt``. If included in a subdirectory it does nothing.
+# This allows you to use it safely in your main ``CMakeLists.txt`` and include
+# your project using ``add_subdirectory`` (for example when using it with
+# :cmake:module:`FetchContent`).
+#
+# If the ``uninstall`` target already exists, the module does nothing.
+
+#=============================================================================
+# Copyright 2008-2013 Kitware, Inc.
+# Copyright 2013 Istituto Italiano di Tecnologia (IIT)
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+# AddUninstallTarget works only when included in the main CMakeLists.txt
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+  return()
+endif()
+
+# The name of the target is uppercase in MSVC and Xcode (for coherence with the
+# other standard targets)
+if("${CMAKE_GENERATOR}" MATCHES "^(Visual Studio|Xcode)")
+  set(_uninstall "UNINSTALL")
+else()
+  set(_uninstall "uninstall")
+endif()
+
+# If target is already defined don't do anything
+if(TARGET ${_uninstall})
+  return()
+endif()
+
+
+set(_filename cmake_uninstall.cmake)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${_filename}"
+"if(NOT EXISTS \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\")
+  message(WARNING \"Cannot find install manifest: \\\"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\\\"\")
+  return()
+endif()
+
+file(READ \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\" files)
+string(STRIP \"\${files}\" files)
+string(REGEX REPLACE \"\\n\" \";\" files \"\${files}\")
+list(REVERSE files)
+foreach(file \${files})
+  if(IS_SYMLINK \"\$ENV{DESTDIR}\${file}\" OR EXISTS \"\$ENV{DESTDIR}\${file}\")
+    message(STATUS \"Uninstalling: \$ENV{DESTDIR}\${file}\")
+    execute_process(
+      COMMAND \${CMAKE_COMMAND} -E remove \"\$ENV{DESTDIR}\${file}\"
+      OUTPUT_VARIABLE rm_out
+      RESULT_VARIABLE rm_retval)
+    if(NOT \"\${rm_retval}\" EQUAL 0)
+      message(FATAL_ERROR \"Problem when removing \\\"\$ENV{DESTDIR}\${file}\\\"\")
+    endif()
+  else()
+    message(STATUS \"Not-found: \$ENV{DESTDIR}\${file}\")
+  endif()
+endforeach(file)
+")
+
+set(_desc "Uninstall the project...")
+if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+  set(_comment COMMAND \$\(CMAKE_COMMAND\) -E cmake_echo_color --switch=$\(COLOR\) --cyan "${_desc}")
+else()
+  set(_comment COMMENT "${_desc}")
+endif()
+add_custom_target(${_uninstall}
+                  ${_comment}
+                  COMMAND ${CMAKE_COMMAND} -P ${_filename}
+                  USES_TERMINAL
+                  BYPRODUCTS uninstall_byproduct
+                  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+set_property(SOURCE uninstall_byproduct PROPERTY SYMBOLIC 1)
+
+set_property(TARGET ${_uninstall} PROPERTY FOLDER "CMakePredefinedTargets")

--- a/3rdparty/ycm-0.12/FindOctave.cmake
+++ b/3rdparty/ycm-0.12/FindOctave.cmake
@@ -1,0 +1,167 @@
+# - Find Octave
+# GNU Octave is a high-level interpreted language, primarily intended for numerical computations.
+# available at http://www.gnu.org/software/octave/
+#
+# This module defines:
+#  OCTAVE_EXECUTABLE           - octave interpreter
+#  OCTAVE_INCLUDE_DIRS         - include path for mex.h, mexproto.h
+#  OCTAVE_LIBRARIES            - required libraries: octinterp, octave, cruft
+#  OCTAVE_OCTINTERP_LIBRARY    - path to the library octinterp
+#  OCTAVE_OCTAVE_LIBRARY       - path to the library octave
+#  OCTAVE_CRUFT_LIBRARY        - path to the library cruft
+#  OCTAVE_VERSION_STRING       - octave version string
+#  OCTAVE_MAJOR_VERSION        - major version
+#  OCTAVE_MINOR_VERSION        - minor version
+#  OCTAVE_PATCH_VERSION        - patch version
+#  OCTAVE_OCT_FILE_DIR         - object files that will be dynamically loaded
+#  OCTAVE_OCT_LIB_DIR          - oct libraries
+#
+# The macro octave_add_oct allows to create compiled modules.
+# octave_add_oct ( target_name
+#         [SOURCES] source1 [source2 ...]
+#         [LINK_LIBRARIES  lib1 [lib2 ...]]
+#         [EXTENSION ext]
+# )
+#
+#=============================================================================
+# Copyright 2013, Julien Schueller
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+#=============================================================================
+find_program( OCTAVE_CONFIG_EXECUTABLE
+              NAMES octave-config
+            )
+if ( OCTAVE_CONFIG_EXECUTABLE )
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p BINDIR
+                    OUTPUT_VARIABLE OCTAVE_BIN_PATHS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTINCLUDEDIR
+                    OUTPUT_VARIABLE OCTAVE_INCLUDE_PATHS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTLIBDIR
+                    OUTPUT_VARIABLE OCTAVE_LIBRARIES_PATHS
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTFILEDIR
+                    OUTPUT_VARIABLE OCTAVE_OCT_FILE_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p OCTLIBDIR
+                    OUTPUT_VARIABLE OCTAVE_OCT_LIB_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -v
+                    OUTPUT_VARIABLE OCTAVE_VERSION_STRING
+                    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+  if ( OCTAVE_VERSION_STRING )
+    string ( REGEX REPLACE "([0-9]+)\\..*" "\\1" OCTAVE_MAJOR_VERSION ${OCTAVE_VERSION_STRING} )
+    string ( REGEX REPLACE "[0-9]+\\.([0-9]+).*" "\\1" OCTAVE_MINOR_VERSION ${OCTAVE_VERSION_STRING} )
+    string ( REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" OCTAVE_PATCH_VERSION ${OCTAVE_VERSION_STRING} )
+  endif ()
+endif ()
+find_program( OCTAVE_EXECUTABLE
+              HINTS ${OCTAVE_BIN_PATHS}
+              NAMES octave
+            )
+find_library( OCTAVE_OCTINTERP_LIBRARY
+              NAMES octinterp liboctinterp
+              HINTS ${OCTAVE_LIBRARIES_PATHS}
+            )
+find_library( OCTAVE_OCTAVE_LIBRARY
+              NAMES octave liboctave
+              HINTS ${OCTAVE_LIBRARIES_PATHS}
+            )
+find_library( OCTAVE_CRUFT_LIBRARY
+              NAMES cruft libcruft
+              HINTS ${OCTAVE_LIBRARIES_PATHS}
+            )
+
+set ( OCTAVE_LIBRARIES ${OCTAVE_OCTINTERP_LIBRARY} )
+list ( APPEND OCTAVE_LIBRARIES ${OCTAVE_OCTAVE_LIBRARY} )
+if ( ${OCTAVE_CRUFT_LIBRARY} )
+  list ( APPEND OCTAVE_LIBRARIES ${OCTAVE_CRUFT_LIBRARY} )
+endif ()
+
+find_path ( OCTAVE_INCLUDE_DIR
+            NAMES mex.h
+            HINTS ${OCTAVE_INCLUDE_PATHS}
+          )
+
+set ( OCTAVE_INCLUDE_DIRS ${OCTAVE_INCLUDE_DIR} )
+macro ( octave_add_oct FUNCTIONNAME )
+  set ( _CMD SOURCES )
+  set ( _SOURCES )
+  set ( _LINK_LIBRARIES )
+  set ( _EXTENSION )
+  set ( _OCT_EXTENSION oct )
+  foreach ( _ARG ${ARGN})
+    if ( ${_ARG} MATCHES SOURCES )
+      set ( _CMD SOURCES )
+    elseif ( ${_ARG} MATCHES LINK_LIBRARIES  )
+      set ( _CMD LINK_LIBRARIES  )
+    elseif ( ${_ARG} MATCHES EXTENSION )
+      set ( _CMD EXTENSION )
+    else ()
+      if ( ${_CMD} MATCHES SOURCES )
+        list ( APPEND _SOURCES "${_ARG}" )
+      elseif ( ${_CMD} MATCHES LINK_LIBRARIES  )
+        list ( APPEND _LINK_LIBRARIES "${_ARG}" )
+      elseif ( ${_CMD} MATCHES EXTENSION )
+        set ( _OCT_EXTENSION ${_ARG} )
+      endif ()
+    endif ()
+  endforeach ()
+  add_library ( ${FUNCTIONNAME} SHARED ${_SOURCES} )
+  target_link_libraries ( ${FUNCTIONNAME} ${OCTAVE_LIBRARIES} ${_LINK_LIBRARIES} )
+  set_target_properties ( ${FUNCTIONNAME} PROPERTIES
+    PREFIX ""
+    SUFFIX  ".${_OCT_EXTENSION}"
+  )
+endmacro ()
+# handle REQUIRED and QUIET options
+include ( FindPackageHandleStandardArgs )
+if ( CMAKE_VERSION LESS 2.8.3 )
+  find_package_handle_standard_args ( Octave DEFAULT_MSG OCTAVE_EXECUTABLE OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES OCTAVE_VERSION_STRING )
+else ()
+  find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
+endif ()
+mark_as_advanced (
+  OCTAVE_OCT_FILE_DIR
+  OCTAVE_OCT_LIB_DIR
+  OCTAVE_OCTINTERP_LIBRARY
+  OCTAVE_OCTAVE_LIBRARY
+  OCTAVE_CRUFT_LIBRARY
+  OCTAVE_LIBRARIES
+  OCTAVE_INCLUDE_DIR
+  OCTAVE_INCLUDE_DIRS
+  OCTAVE_VERSION_STRING
+  OCTAVE_MAJOR_VERSION
+  OCTAVE_MINOR_VERSION
+  OCTAVE_PATCH_VERSION
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,117 @@
+# Copyright (C) 2020 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the Apache-2.0 license
+
+cmake_minimum_required(VERSION 3.16)
+
+set(OSQP_MATLAB_UPSTREAM_VERSION 0.6.2)
+set(OSQP_MATLAB_CMAKE_REVISION 0)
+set(OSQP_MATLAB_CMAKE_VERSION "${OSQP_MATLAB_UPSTREAM_VERSION}.${OSQP_MATLAB_CMAKE_REVISION}")
+project(osqp-matlab-cmake-buildsystem
+  LANGUAGES C CXX
+  VERSION ${OSQP_MATLAB_CMAKE_VERSION})
+
+include(GNUInstallDirs)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
+option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+option(OSQP_MATLAB_USES_MATLAB "Do you want to create the MATLAB bindings" ON)
+option(OSQP_MATLAB_USES_OCTAVE "Do you want to create the Octave bindings" OFF)
+
+set(OSQP_MATLAB_INSTALL_MATLAB_LIBDIR "mex" CACHE
+    STRING "Location (relative to the install prefix) in which the Matlab mex libraries are installed.")
+set(OSQP_MATLAB_INSTALL_MATLAB_MFILESDIR "mex" CACHE
+    STRING "Location (relative to the install prefix) in which the Matlab .m files are installed.")
+set(OSQP_MATLAB_INSTALL_OCTAVE_LIBDIR "octave" CACHE
+    STRING "Location (relative to the install prefix) in which the Octave mex libraries are installed.")
+set(OSQP_MATLAB_INSTALL_OCTAVE_MFILESDIR "octave" CACHE
+    STRING "Location (relative to the install prefix) in which the Octave .m files are installed.")
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/ycm-0.12)
+
+# Enable RPATH support for installed binaries and libraries
+include(AddInstallRPATHSupport)
+add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"
+  LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"
+  INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
+  USE_LINK_PATH)
+
+# Encourage user to specify a build type (e.g. Release, Debug, etc.), otherwise set it to Release.
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+  endif()
+endif()
+
+## Find qdldl and osqp dependency
+find_package(qdldl REQUIRED)
+find_package(osqp REQUIRED)
+
+## Clone osqp-matlab repository
+## To use with some the osqp-matlab source coming from some other source, comment out
+# the FetchContent* commands and set manually osqp-matlab_SOURCE_DIR
+include(FetchContent)
+# Temporary pointing to a fork, see https://github.com/oxfordcontrol/osqp-matlab/pull/34
+FetchContent_Declare(
+  osqp-matlab
+  GIT_REPOSITORY https://github.com/traversaro/osqp-matlab
+# GIT_TAG        v${OSQP_MATLAB_UPSTREAM_VERSION}
+  GIT_TAG        aff21017e4396aed8cf7537a14fe540ae5b0c374
+  )
+
+FetchContent_MakeAvailable(osqp-matlab)
+
+# Workaround for missing include https://github.com/oxfordcontrol/osqp-matlab/issues/27
+file(DOWNLOAD "https://raw.githubusercontent.com/oxfordcontrol/osqp/v${OSQP_MATLAB_UPSTREAM_VERSION}/lin_sys/direct/qdldl/qdldl_interface.h" ${CMAKE_CURRENT_BINARY_DIR}/workaround_include/qdldl_interface.h)
+
+# Common source files
+set(M_FILES ${osqp-matlab_SOURCE_DIR}/osqp.m)
+set(MEX_FILES ${osqp-matlab_SOURCE_DIR}/osqp_mex.hpp ${osqp-matlab_SOURCE_DIR}/osqp_mex.cpp)
+
+if(OSQP_MATLAB_USES_MATLAB)
+  find_package(Matlab REQUIRED)
+  matlab_add_mex(
+      NAME osqp_mex_matlab
+      OUTPUT_NAME osqp_mex
+      SRC ${MEX_FILES}
+    LINK_TO qdldl::qdldl osqp::osqp)
+  # Workaround for missing include https://github.com/oxfordcontrol/osqp-matlab/issues/27
+  target_include_directories(osqp_mex_matlab PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/workaround_include)
+  install(
+    TARGETS osqp_mex_matlab
+    EXPORT ${PROJECT_NAME}
+    DESTINATION ${OSQP_MATLAB_INSTALL_MATLAB_LIBDIR})
+  install(
+    FILES ${M_FILES}
+    DESTINATION ${OSQP_MATLAB_INSTALL_MATLAB_MFILESDIR})
+endif()
+
+if(OSQP_MATLAB_USES_OCTAVE)
+  find_package(Octave REQUIRED)
+
+  add_library(osqp_mex_octave MODULE  ${MEX_FILES})
+  set_target_properties(osqp_mex_octave PROPERTIES DEBUG_POSTFIX "")
+  target_include_directories(osqp_mex_octave PUBLIC ${OCTAVE_INCLUDE_DIRS})
+  target_link_libraries(osqp_mex_octave ${OCTAVE_LIBRARIES} qdldl::qdldl osqp::osqp)
+  if(APPLE)
+    set_target_properties(osqp_mex_octave PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  endif()
+  set_target_properties(osqp_mex_octave
+    PROPERTIES OUTPUT_NAME osqp_mex
+               PREFIX ""
+               SUFFIX .mex)
+  # Workaround for missing include https://github.com/oxfordcontrol/osqp-matlab/issues/27
+  target_include_directories(osqp_mex_octave PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/workaround_include)
+  install(
+    TARGETS osqp_mex_octave
+    EXPORT ${PROJECT_NAME}
+    DESTINATION ${OSQP_MATLAB_INSTALL_OCTAVE_LIBDIR})
+  install(
+    FILES ${M_FILES}
+    DESTINATION ${OSQP_MATLAB_INSTALL_OCTAVE_MFILESDIR})
+endif()
+
+include(AddUninstallTarget)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repo contains a drop-in CMake buildsystem for the osqp-matlab bindings mantained at .
+This repo contains a drop-in CMake buildsystem for the osqp-matlab bindings mantained at https://github.com/oxfordcontrol/osqp-matlab .
 
 **If you are just interested in using OSQP in MATLAB, please follow the official instructions at https://osqp.org/docs/get_started/matlab.html.**
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # osqp-matlab-cmake-buildsystem
+
+## Overview
+
+This repo contains a drop-in CMake buildsystem for the osqp-matlab bindings mantained at .
+
+**If you are just interested in using OSQP in MATLAB, please follow the official instructions at https://osqp.org/docs/get_started/matlab.html.**
+
+This repo is only useful if for any need to compile the MATLAB extension against a OSQP library that is already in your system, for example
+if you are also using OSQP in other software that is loaded by MATLAB, and you want to avoid ABI incompatibilities.
+
+**At the moment, this CMake build system does not support the osqp codegen functionalities. If you need that, please use the official binaries.**
+
+## Usage
+
+How to use this repo
+
+1. Install osqp in your system, and make sure that it can be find by CMake.
+
+2. Clone the repository
+
+~~~
+git clone git://github.com/dic-iit/osqp-matlab-cmake-buildsystem
+~~~
+
+3. Build it
+
+~~~
+cd osqp-matlab-cmake-buildsystem
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX:PATH=<install-prefix> ..
+cmake --build . --config Release
+cmake --install . --config Release
+~~~
+
+4. Use it
+
+Add the `<install-prefix>/mex` directory to the MATLAB path.
+
+## License
+
+Materials in this repository are distributed under the following license:
+
+> All software is licensed under the Apache-2 License. See [LICENSE](./LICENSE) file for details.
+
+## FAQ
+
+### How the version is chosen?
+
+The version of this `CMake` project is chosen in accordance of the original project, plus a fourth version that describes if several CMake buildsystem
+version were release, for example the version `x.y.z.t` is the one corresponding to the `x.y.z` version of osqp-matlab, while `t` is the number that can be
+increase is changes are done to the CMake buildsystem.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ How to use this repo
 2. Clone the repository
 
 ~~~
-git clone git://github.com/dic-iit/osqp-matlab-cmake-buildsystem
+git clone https://github.com/dic-iit/osqp-matlab-cmake-buildsystem.git
 ~~~
 
 3. Build it

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Materials in this repository are distributed under the following license:
 
 The version of this `CMake` project is chosen in accordance of the original project, plus a fourth version that describes if several CMake buildsystem
 versions were released, for example the version `x.y.z.t` is the one corresponding to the `x.y.z` version of osqp-matlab, while `t` is the number that can be
-increase is changes are done to the CMake buildsystem.
+increased if changes are done to the CMake buildsystem.

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ Materials in this repository are distributed under the following license:
 ### How the version is chosen?
 
 The version of this `CMake` project is chosen in accordance of the original project, plus a fourth version that describes if several CMake buildsystem
-version were release, for example the version `x.y.z.t` is the one corresponding to the `x.y.z` version of osqp-matlab, while `t` is the number that can be
+versions were released, for example the version `x.y.z.t` is the one corresponding to the `x.y.z` version of osqp-matlab, while `t` is the number that can be
 increase is changes are done to the CMake buildsystem.


### PR DESCRIPTION
Most of the relevant information is provided in the README. This is convenient to easily add the osqp-matlab to the robotology-superbuild, to fix https://github.com/robotology/robotology-superbuild/issues/575 . 

There are a few upstream problems: 
* https://github.com/oxfordcontrol/osqp-matlab/issues/27
* https://github.com/oxfordcontrol/osqp-matlab/pull/34

But for the time being the repo contains local workaround that should be easy to revert once the issue are solved. 

I already tested the bindings with the example https://github.com/oxfordcontrol/osqp-matlab/blob/master/examples/easy_lasso_qp.m and they seem to be working fine. Once this is merged, I will release the version `v0.6.2.0` . 